### PR TITLE
fix: [GET-19] Add /api/health endpoint that returns system status

### DIFF
--- a/lib/fac_web/controllers/health_controller.ex
+++ b/lib/fac_web/controllers/health_controller.ex
@@ -1,0 +1,13 @@
+defmodule FacWeb.HealthController do
+  use FacWeb, :controller
+
+  @version Mix.Project.config()[:version]
+
+  def index(conn, _params) do
+    json(conn, %{
+      status: "ok",
+      timestamp: DateTime.utc_now() |> DateTime.to_iso8601(),
+      version: @version
+    })
+  end
+end

--- a/lib/fac_web/router.ex
+++ b/lib/fac_web/router.ex
@@ -20,10 +20,11 @@ defmodule FacWeb.Router do
     get "/", PageController, :home
   end
 
-  # Other scopes may use custom stacks.
-  # scope "/api", FacWeb do
-  #   pipe_through :api
-  # end
+  scope "/api", FacWeb do
+    pipe_through :api
+
+    get "/health", HealthController, :index
+  end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:fac, :dev_routes) do

--- a/test/fac_web/controllers/health_controller_test.exs
+++ b/test/fac_web/controllers/health_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule FacWeb.HealthControllerTest do
+  use FacWeb.ConnCase
+
+  test "GET /api/health returns ok status", %{conn: conn} do
+    conn = get(conn, ~p"/api/health")
+    assert %{"status" => "ok", "timestamp" => timestamp, "version" => version} =
+             json_response(conn, 200)
+
+    assert is_binary(timestamp)
+    assert {:ok, _, _} = DateTime.from_iso8601(timestamp)
+    assert is_binary(version)
+  end
+end


### PR DESCRIPTION
Resolves #1

## Summary
Automated fix by Claude agent.

- Created `lib/fac_web/controllers/health_controller.ex`
- Created `test/fac_web/controllers/health_controller_test.exs`
- Updated router

## Verification
- [ ] `mix compile --warnings-as-errors` passes
- [ ] `mix test` passes
- [ ] `mix credo --strict` passes
- [ ] `mix format --check-formatted` passes